### PR TITLE
Elegant alternative for download button

### DIFF
--- a/ui/components/common/CommonToolbar.js
+++ b/ui/components/common/CommonToolbar.js
@@ -10,6 +10,7 @@ const CommonToolbar = ({ buttons, onFilter }) => {
             bsStyle="primary"
             onClick={button.cb}
             disabled={button.enabled === false}
+            {...button.props}
         >
             {button.title}
         </Button>

--- a/ui/components/schema/SchemaContainer.js
+++ b/ui/components/schema/SchemaContainer.js
@@ -45,17 +45,6 @@ class SchemaContainer extends Component {
         this.setState({ schema });
     }
 
-    export() {
-        const { getSchema: { id } } = this.props.data;
-        const path = `/schema/${id}`;
-        const link = document.createElement("A");
-        link.href = path;
-        link.download = path.substr(path.lastIndexOf("/") + 1);
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-    }
-
     save() {
         const { schema } = this.state;
         const { getSchema } = this.props.data;
@@ -83,13 +72,13 @@ class SchemaContainer extends Component {
     }
 
     getToolbarButtons() {
-        const { getSchema: { valid } } = this.props.data;
+        const { getSchema: { id, valid } } = this.props.data;
         return [
             {
                 title: "Download Schema",
-                cb: () => this.export(),
                 id: "export_schema",
-                enabled: valid
+                enabled: valid,
+                props: { href: `/schema/${id}` }
             },
             {
                 title: "Save Schema",


### PR DESCRIPTION
Simply sets the `href` property of the button by passing a "custom props" property to the generic button.

In a separate PR I plan to make buttons completely generic, following this very approach:
```jsx
// in CommonToolbar
const elements = buttons && buttons.map(button => (
        <Button {...button.props}>
            {button.title}
        </Button>
    ));
```

```javascript
// in *Container
getToolbarButtons() {
        const { getSchema: { id, valid } } = this.props.data;
        return [
            {
                title: "Download Schema",
                props: {
                    href: `/schema/${id}`,
                    id: "export_schema",
                    disabled: !valid,
                }
            },
            ...
        ];
    }
```
This way we can add props as we need.